### PR TITLE
Allow users to set different overclocks per card

### DIFF
--- a/files/nvidia-overclock.sh
+++ b/files/nvidia-overclock.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-#Skip manual settings per card.
-SKIP_MANUAL_SETTINGS=true
+# Use different settings per card.
+USE_INDIVIDUAL_SETTINGS=false
 # GPUGraphicsClockOffset
 MY_CLOCK="150"
 # GPUMemoryTransferRateOffset
 MY_MEM="600"
 # GPUTargetFanSpeed (%)
-MY_FAN="85"
+MY_FAN="75"
 
 LINE_COUNT="$(nvidia-smi -L | wc -l)"
 for (( MY_DEVICE = 0; MY_DEVICE < ${LINE_COUNT}; MY_DEVICE++ )); do
@@ -18,7 +18,7 @@ for (( MY_DEVICE = 0; MY_DEVICE < ${LINE_COUNT}; MY_DEVICE++ )); do
     # Enable fan speed control.
     DISPLAY=:0 XAUTHORITY=/var/lib/mdm/:0.Xauth nvidia-settings -a "[gpu:$MY_DEVICE]/GPUFanControlState=1"
 
-    if [ $SKIP_MANUAL_SETTINGS = false ]; then
+    if [ $USE_INDIVIDUAL_SETTINGS = true ]; then
         echo "Enter clock speed offset for GPU:$MY_DEVICE (${GPU_NAME}) [Press enter/return to skip. | Don't include the + symbol.]"
         read CLOCK_OFFSET
         if ! [ "$CLOCK_OFFSET" -eq "$CLOCK_OFFSET" ] 2> /dev/null; then

--- a/files/nvidia-overclock.sh
+++ b/files/nvidia-overclock.sh
@@ -1,32 +1,51 @@
 #!/usr/bin/env bash
 
-
-# Overclocking with nvidia-settings
-# Increase or decrease in small increments (+/- 25)
-
-
+#Skip manual settings per card.
+SKIP_MANUAL_SETTINGS=true
 # GPUGraphicsClockOffset
 MY_CLOCK="150"
 # GPUMemoryTransferRateOffset
 MY_MEM="600"
-
 # GPUTargetFanSpeed (%)
-MY_FAN="75"
+MY_FAN="85"
 
+LINE_COUNT="$(nvidia-smi -L | wc -l)"
+for (( MY_DEVICE = 0; MY_DEVICE < ${LINE_COUNT}; MY_DEVICE++ )); do
+    FIX_LINE_NUMBER="$(expr $MY_DEVICE + 1)"
+    GPU_NAME="$(nvidia-smi --query-gpu=gpu_name --format=csv,noheader | sed -n ${FIX_LINE_NUMBER}p)"
+    # Enable control of offsets.
+    DISPLAY=:0 XAUTHORITY=/var/lib/mdm/:0.Xauth nvidia-settings -a "[gpu:$MY_DEVICE]/GPUPowerMizerMode=1"
+    # Enable fan speed control.
+    DISPLAY=:0 XAUTHORITY=/var/lib/mdm/:0.Xauth nvidia-settings -a "[gpu:$MY_DEVICE]/GPUFanControlState=1"
 
-# Graphics card 1 to 6
-for MY_DEVICE in {0..5}
-do
-	DISPLAY=:0 XAUTHORITY=/var/lib/mdm/:0.Xauth nvidia-settings -a "[gpu:$MY_DEVICE]/GPUPowerMizerMode=1"
-	# Fan speed
-	DISPLAY=:0 XAUTHORITY=/var/lib/mdm/:0.Xauth nvidia-settings -a "[gpu:$MY_DEVICE]/GPUFanControlState=1"
-	DISPLAY=:0 XAUTHORITY=/var/lib/mdm/:0.Xauth nvidia-settings -a "[fan:$MY_DEVICE]/GPUTargetFanSpeed=$MY_FAN"
-	# Grafics clock
-	DISPLAY=:0 XAUTHORITY=/var/lib/mdm/:0.Xauth nvidia-settings -a "[gpu:$MY_DEVICE]/GPUGraphicsClockOffset[3]=$MY_CLOCK"
-	# Memory clock
-	DISPLAY=:0 XAUTHORITY=/var/lib/mdm/:0.Xauth nvidia-settings -a "[gpu:$MY_DEVICE]/GPUMemoryTransferRateOffset[3]=$MY_MEM"
+    if [ $SKIP_MANUAL_SETTINGS = false ]; then
+        echo "Enter clock speed offset for GPU:$MY_DEVICE (${GPU_NAME}) [Press enter/return to skip. | Don't include the + symbol.]"
+        read CLOCK_OFFSET
+        if ! [ "$CLOCK_OFFSET" -eq "$CLOCK_OFFSET" ] 2> /dev/null; then
+            CLOCK_OFFSET=$MY_CLOCK
+            echo "Manual clock speed offset for GPU:$MY_DEVICE (${GPU_NAME}) skipped. Using +$CLOCK_OFFSET"
+        fi
+        echo
+        echo "Enter memory speed offset for GPU:$MY_DEVICE (${GPU_NAME}) [Press enter/return to skip. | Don't include the + symbol.]"
+        read MEM_OFFSET
+        if ! [ "$MEM_OFFSET" -eq "$MEM_OFFSET" ] 2> /dev/null; then
+            MEM_OFFSET=$MY_MEM
+            echo "Manual memory speed offset for GPU:$MY_DEVICE (${GPU_NAME}) skipped. Using +$MEM_OFFSET"
+        fi
+        echo
+        echo "Enter fan speed percentage for GPU:$MY_DEVICE (${GPU_NAME}) [Press enter/return to skip. | Don't include the % symbol.]"
+        read FAN_PERCENT
+        if ! [ "$FAN_PERCENT" -eq "$FAN_PERCENT" ] 2> /dev/null; then
+            FAN_PERCENT=$MY_FAN
+            echo "Manual fan speed percentage for GPU:$MY_DEVICE (${GPU_NAME}) skipped. Using $FAN_PERCENT%"
+        fi
+    else
+        CLOCK_OFFSET=$MY_CLOCK
+        MEM_OFFSET=$MY_MEM
+        FAN_PERCENT=$MY_FAN
+    fi
+    DISPLAY=:0 XAUTHORITY=/var/lib/mdm/:0.Xauth nvidia-settings -a "[gpu:$MY_DEVICE]/GPUGraphicsClockOffset[3]=$CLOCK_OFFSET"
+    DISPLAY=:0 XAUTHORITY=/var/lib/mdm/:0.Xauth nvidia-settings -a "[gpu:$MY_DEVICE]/GPUMemoryTransferRateOffset[3]=$MEM_OFFSET"
+    DISPLAY=:0 XAUTHORITY=/var/lib/mdm/:0.Xauth nvidia-settings -a "[fan:$MY_DEVICE]/GPUTargetFanSpeed=$FAN_PERCENT"
+    echo
 done
-
-echo
-echo "Done"
-echo


### PR DESCRIPTION
This is disabled by default since it might not be useful for most users. I also made it so that the script will work for any number of cards, 1 card up to even 14 cards if possible.

Sorry if the code is bad, I rarely ever use bash to write scripts in.