### PR TITLE
Suggested fix for nvidia-overclock.sh not setting watt

### DIFF
--- a/files/nvidia-overclock.sh
+++ b/files/nvidia-overclock.sh
@@ -28,6 +28,9 @@ do
 		nvidia-settings -a "[gpu:$MY_DEVICE]/GPUGraphicsClockOffset[3]=$MY_CLOCK"
 		# Memory clock
 		nvidia-settings -a "[gpu:$MY_DEVICE]/GPUMemoryTransferRateOffset[3]=$MY_MEM"
+                # Set watt/powerlimit
+                sudo nvidia-smi -i "$MY_DEVICE" -pl "$MY_WATT"
+
 	fi
 done
 

--- a/files/nvidia-overclock.sh
+++ b/files/nvidia-overclock.sh
@@ -24,11 +24,11 @@ do
 		# Fan speed
 		nvidia-settings -a "[gpu:$MY_DEVICE]/GPUFanControlState=1"
 		nvidia-settings -a "[fan:$MY_DEVICE]/GPUTargetFanSpeed=$MY_FAN"
-		# Grafics clock
+		# Graphics clock
 		nvidia-settings -a "[gpu:$MY_DEVICE]/GPUGraphicsClockOffset[3]=$MY_CLOCK"
 		# Memory clock
 		nvidia-settings -a "[gpu:$MY_DEVICE]/GPUMemoryTransferRateOffset[3]=$MY_MEM"
-                # Set watt/powerlimit
+                # Set watt/powerlimit. This is also set in miner.sh at autostart.
                 sudo nvidia-smi -i "$MY_DEVICE" -pl "$MY_WATT"
 	fi
 done

--- a/files/nvidia-overclock.sh
+++ b/files/nvidia-overclock.sh
@@ -30,7 +30,6 @@ do
 		nvidia-settings -a "[gpu:$MY_DEVICE]/GPUMemoryTransferRateOffset[3]=$MY_MEM"
                 # Set watt/powerlimit
                 sudo nvidia-smi -i "$MY_DEVICE" -pl "$MY_WATT"
-
 	fi
 done
 


### PR DESCRIPTION
I've added the powerlimit/watt setting to be run with nvidia-overclock.sh, not only on start of miner.sh. Powerlimiting is an important part of tuning performance so it should apply as expected after changing in setup.