### PR TITLE
Update nvidia-overclock.sh

### DIFF
--- a/files/nvidia-overclock.sh
+++ b/files/nvidia-overclock.sh
@@ -22,14 +22,8 @@ for MY_DEVICE in {0..18}
 do
 	# Check if card exists
 	if nvidia-smi -i $MY_DEVICE >> /dev/null 2>&1; then
-		nvidia-settings -a "[gpu:$MY_DEVICE]/GPUPowerMizerMode=1"
-		# Fan speed
-		nvidia-settings -a "[gpu:$MY_DEVICE]/GPUFanControlState=1"
-		nvidia-settings -a "[fan:$MY_DEVICE]/GPUTargetFanSpeed=$MY_FAN"
-		# Graphics clock
-		nvidia-settings -a "[gpu:$MY_DEVICE]/GPUGraphicsClockOffset[3]=$MY_CLOCK"
-		# Memory clock
-		nvidia-settings -a "[gpu:$MY_DEVICE]/GPUMemoryTransferRateOffset[3]=$MY_MEM"
+	        # Set Fan speed , Graphics clock, Memory Clock
+		nvidia-settings -a "[gpu:$MY_DEVICE]/GPUPowerMizerMode=1" -a "[gpu:$MY_DEVICE]/GPUFanControlState=1" -a "[fan:$MY_DEVICE]/GPUTargetFanSpeed=$MY_FAN" -a "[gpu:$MY_DEVICE]/GPUGraphicsClockOffset[3]=$MY_CLOCK" -a "[gpu:$MY_DEVICE]/GPUMemoryTransferRateOffset[3]=$MY_MEM"
 		# Set watt/powerlimit. This is also set in miner.sh at autostart.
 		sudo nvidia-smi -i "$MY_DEVICE" -pl "$MY_WATT"
 	fi


### PR DESCRIPTION
I propose this change, it speeds up a lot , instead of calling the driver 4 times, you only call it once and get the job done faster.
It also reduces the risk of a hang in 13 GTX1070 since nvidia driver does not like much to have more than 6 GPUs in one rig.