### PR TITLE
Environment variables for launch of ethminer

### DIFF
--- a/files/miner.sh
+++ b/files/miner.sh
@@ -20,6 +20,11 @@ sudo nvidia-smi -pm ENABLED
 sudo nvidia-smi -pl "$MY_WATT"
 echo
 
+export GPU_FORCE_64BIT_PTR=0
+export GPU_MAX_HEAP_SIZE=100
+export GPU_USE_SYNC_OBJECTS=1
+export GPU_MAX_ALLOC_PERCENT=100
+export GPU_SINGLE_ALLOC_PERCENT=100
 export CUDA_DEVICE_ORDER=PCI_BUS_ID
 
 #
@@ -29,7 +34,7 @@ export CUDA_DEVICE_ORDER=PCI_BUS_ID
 # ethminer
 # https://github.com/ethereum-mining/ethminer
 # Use -G (opencl) or -U (cuda) flag to select GPU platform.
-~/ethereum-mining/ethminer/build/ethminer/ethminer -U -S "eu1.ethermine.org:4444" -FS "us1.ethermine.org:4444" -O "$MY_ADDRESS.$MY_RIG"
+~/ethereum-mining/ethminer/build/ethminer/ethminer --farm-recheck 10000 -U -S "eu1.ethermine.org:4444" -FS "us1.ethermine.org:4444" -O "$MY_ADDRESS.$MY_RIG"
 
 # Claymore's Dual Ethereum+Decred AMD+NVIDIA GPU Miner
 # https://github.com/nanopool/Claymore-Dual-Miner

--- a/files/miner.sh
+++ b/files/miner.sh
@@ -20,11 +20,7 @@ sudo nvidia-smi -pm ENABLED
 sudo nvidia-smi -pl "$MY_WATT"
 echo
 
-export GPU_FORCE_64BIT_PTR=0
-export GPU_MAX_HEAP_SIZE=100
-export GPU_USE_SYNC_OBJECTS=1
-export GPU_MAX_ALLOC_PERCENT=100
-export GPU_SINGLE_ALLOC_PERCENT=100
+export CUDA_DEVICE_ORDER=PCI_BUS_ID
 
 #
 # Ethereum Mining
@@ -33,7 +29,7 @@ export GPU_SINGLE_ALLOC_PERCENT=100
 # ethminer
 # https://github.com/ethereum-mining/ethminer
 # Use -G (opencl) or -U (cuda) flag to select GPU platform.
-~/ethereum-mining/ethminer/build/ethminer/ethminer --farm-recheck 200 -U -S "eu1.ethermine.org:4444" -FS "us1.ethermine.org:4444" -O "$MY_ADDRESS.$MY_RIG"
+~/ethereum-mining/ethminer/build/ethminer/ethminer -U -S "eu1.ethermine.org:4444" -FS "us1.ethermine.org:4444" -O "$MY_ADDRESS.$MY_RIG"
 
 # Claymore's Dual Ethereum+Decred AMD+NVIDIA GPU Miner
 # https://github.com/nanopool/Claymore-Dual-Miner


### PR DESCRIPTION
Since version 0.13 the express export of GPU_x environment variables is
no longer needed as they are already embedded into ethminer itself.
On the other hand is relevant to add CUDA_DEVICE_ORDER as this
guarantess that CUDAx kernels are numbered as the order of cards on the
pci bus. This is important for debugging and overclocking.
Furthermore the --farm-recheck parameter has no meaning anymore: in
stratum mode it only affected the display interval of hashrate while
since release 0.14 of ethminer it has been completely dropped (in
stratum) as the hashrate display interval has been fixed to 5 seconds.